### PR TITLE
Update README.md and utils

### DIFF
--- a/02_munge/src/fill_discharge_prms.py
+++ b/02_munge/src/fill_discharge_prms.py
@@ -28,8 +28,8 @@ def download_unzip_sb(sb_url, prms_predictions, destination):
         os.makedirs(destination, exist_ok=True)
         sb = sciencebasepy.SbSession()
         sb.download_file(sb_url, prms_predictions+'.zip', destination)
-        with zipfile.ZipFile(os.path.join(destination,prms_predictions+'.zip'), 'r') as zip_ref:
-            zip_ref.extractall(destination)
+    with zipfile.ZipFile(os.path.join(destination,prms_predictions+'.zip'), 'r') as zip_ref:
+        zip_ref.extractall(destination)
         
 
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,16 @@ The steps for reproducing the results from the manuscript are detailed below. To
 
 4) run `snakemake -s Snakefile_fetch_munge -j` (-j runs the job on the available number of cpus cores, use -j 2 for fewer)
 5) you might have to rerun the same command if there is an error that pops up, this is because snakemake doesn't run rules in order and some directories need to be created
-6) ensure that the `saltfront_updated.csv` is located in `03_model/in` directory
-7) now open the file `03_model/model_config.yaml` and adjust modeling parameters, and change the run_id to whatever you want to name the test run, say Test_Run
-8) run `snakemake -s Snakefile_run_ml_model run_replicates -j`, you should see the training progress in the command window and you should have model results written to `03_model/out/Test_Run/`
+6) now open the file `03_model/model_config.yaml` and adjust modeling parameters, and change the run_id to whatever you want to name the test run, say Test_Run
+7) run `snakemake -s Snakefile_run_ml_model run_replicates -j`, you should see the training progress in the command window and you should have model results written to `03_model/out/Test_Run/`
 
 #### To analyze model output and (re)produce figures:
 
-9) To calculate functional performance for model output:
+8) To calculate functional performance for model output:
     - ensure that COAWST model output are in `03_model/in/COAWST_model_runs/processed`
     - make sure that the parameters in `Snakefile_model_analysis` lines 9-13 describe the desired model run, sources, sinks, and years for analysis. Note: functional performance is calculated on an annual basis
     - run `snakemake -s Snakefile_model_analysis calc_functional_performance_wrapper -j` and the results should be written to `04_analysis/out/"run_id"`
-10) To reproduce manuscript figures:
+9) To reproduce manuscript figures:
     - make sure that the `run_id` parameter in `Snakefile_model_analysis` and `04_analysis/src/results.R` describe the correct model run
     - run `snakemake -s Snakefile_model_analysis generate_manuscript_figures -j`
     - run `snakemake -s generate_expected_gradient_figure -j`

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The steps for reproducing the results from the manuscript are detailed below. To
 #### Steps for reproducibility:
 
 1) clone this repo using `git clone git@github.com:USGS-R/drb-estuary-salinity-ml.git --recurse-submodules`, the `--recurse-submodules` command initiates and updates the `river-dl` submodule housed in `03_model/src/` directory 
-2) add the file `953860.zip` into the `01_fetch/in` folder, the file can be found on S3 in drb_estuary_salinity/01_fetch/in
-3) from within the github cloned directory create the environment using `conda env create -f environment.yaml` or `conda env update --file environment.yaml –prune` if you have already created the environment and just need to update it
+2) from within the github cloned directory create the environment using `conda env create -f environment.yaml` or `conda env update --file environment.yaml –prune` if you have already created the environment and just need to update it
+3) activate your conda environment with `conda activate drb_estuary_salinity`
 
 #### To (re)train the model:  
 

--- a/utils.py
+++ b/utils.py
@@ -35,8 +35,8 @@ def process_to_timestep(df, cols, agg_level, prop_obs_required):
     must have datetimes in a column named 'datetime'
     '''
     # get proportion of measurements available for timestep
-    expected_measurements = df.resample(agg_level, on='datetime').count().mode()[cols].loc[0]
-    observed_measurements = df.resample(agg_level, on='datetime').count()[cols].loc[:]
+    expected_measurements = df.resample(agg_level, on='datetime').count().mode().loc[0]
+    observed_measurements = df.resample(agg_level, on='datetime').count().loc[:]
     prop_df = observed_measurements / expected_measurements
     # calculate averages for timestep
     df = df.resample(agg_level, on='datetime').mean()


### PR DESCRIPTION
- remove instructions checking for data files
- add conda activate environment

Fix error in snakemake pipeline - when using the `resample` function with the `on` paramer (in utils) the version of pandas specified in this environment converts that column to an index. When we try to call all of the columns with `[cols]`, it looks for the datetime column but can't find it (because it is an index). If we drop that bit of code, all columns remain and no error occurs.

Take prms unzip out of `else` statement - sometimes the pipeline errors between download and unzip - the next time we run the pipeline, we still want that file to get unzipped.